### PR TITLE
Add option to URI escape before signing. Fix for issue #12.

### DIFF
--- a/lib/cloudfront-signer.rb
+++ b/lib/cloudfront-signer.rb
@@ -142,6 +142,13 @@ module Aws
         build_url subject, { remove_spaces: true, html_escape: true }, policy_options
       end
 
+      # Public: Sign a url (as above) but URI encode the string first.
+      #
+      # Returns a String
+      def self.sign_url_escaped(subject, policy_options = {})
+        build_url subject, { uri_escape: true }, policy_options
+      end
+
       # Public: Sign a stream path part or filename (spaces are allowed in
       # stream paths and so are not removed).
       #
@@ -159,6 +166,13 @@ module Aws
                   policy_options
       end
 
+      # Public: Sign a stream path or filename but URI encode the string first
+      #
+      # Returns a String
+      def self.sign_path_escaped(subject, policy_options = {})
+        build_url subject, { uri_escape: true }, policy_options
+      end
+
       # Public: Builds a signed url or stream resource name with optional
       # configuration and policy options
       #
@@ -170,6 +184,7 @@ module Aws
         separator = subject =~ /\?/ ? '&' : '?'
 
         subject.gsub!(/\s/, '%20') if configuration_options[:remove_spaces]
+        subject = URI.escape(subject) if configuration_options[:uri_escape]
 
         result = subject +
                  separator +

--- a/spec/signer_spec.rb
+++ b/spec/signer_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Aws::CF::Signer do
         expect(Aws::CF::Signer.sign_path_safe(path)).not_to match(/\?|=|&/)
       end
 
-      it 'URL encodes the signed path when using sign_url_escaped' do
+      it 'URL encodes the signed path when using sign_path_escaped' do
         path = '/préfix/sign me?'
         expect(Aws::CF::Signer.sign_path_escaped(path)).not_to match(/[é ]+/)
       end

--- a/spec/signer_spec.rb
+++ b/spec/signer_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Aws::CF::Signer do
     end
 
     describe 'when signing a url' do
-      let(:url) { 'https://example.com/someresource?opt1=one&opt2=two' }
+      let(:url) { 'https://example.com/somerésource?opt1=one&opt2=two' }
       let(:url_with_spaces) { 'http://example.com/sign me' }
 
       it "doesn't modifies the passed url" do
@@ -99,6 +99,10 @@ RSpec.describe Aws::CF::Signer do
       it 'HTML encodes the signed url when using sign_url_safe' do
         expect(Aws::CF::Signer.sign_url_safe(url)).not_to match(/\?|=|&/)
       end
+
+      it 'URL encodes the signed URL when using sign_url_escaped' do
+        expect(Aws::CF::Signer.sign_url_escaped(url)).not_to match(/é/)
+      end
     end
 
     describe 'when signing a path' do
@@ -107,9 +111,14 @@ RSpec.describe Aws::CF::Signer do
         expect(Aws::CF::Signer.sign_path(path)).to match(/\s/)
       end
 
-      it 'HTML encodes the signed path when using sign_url_safe' do
+      it 'HTML encodes the signed path when using sign_path_safe' do
         path = '/prefix/sign me?'
         expect(Aws::CF::Signer.sign_path_safe(path)).not_to match(/\?|=|&/)
+      end
+
+      it 'URL encodes the signed path when using sign_url_escaped' do
+        path = '/préfix/sign me?'
+        expect(Aws::CF::Signer.sign_path_escaped(path)).not_to match(/[é ]+/)
       end
     end
 


### PR DESCRIPTION
This PR adds the ability to URI escape the path before signing it to make sure that the signature created matches the requested URI when requesting assets from a browser. Fixes #12